### PR TITLE
Fixes for IntelliJ IDEA 2025.3.x (#IU-253.x.y)

### DIFF
--- a/src/main/annotator/SchemeAnnotator.java
+++ b/src/main/annotator/SchemeAnnotator.java
@@ -15,24 +15,30 @@ import static main.lexer.SchemeTokens.COMMENTS;
 
 public class SchemeAnnotator implements Annotator
 {
+  private final SchemeSyntaxHighlighter syntaxHighlighter;
+
+  SchemeAnnotator(SchemeSyntaxHighlighter syntaxHighlighter) {
+    this.syntaxHighlighter = syntaxHighlighter;
+  }
+
   public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder)
   {
     IElementType ele_type = element.getNode().getElementType();
     if (COMMENTS.contains(ele_type)) {
       holder.createInfoAnnotation(element, null)
-              .setTextAttributes(SchemeSyntaxHighlighter.COMMENT);
+              .setTextAttributes(syntaxHighlighter.COMMENT);
     } else if (ele_type == AST.AST_BASIC_ELE_SYMBOL) {
       holder.createInfoAnnotation(element, null)
-              .setTextAttributes(SchemeSyntaxHighlighter.LITERAL);
+              .setTextAttributes(syntaxHighlighter.LITERAL);
     } else if (element instanceof SchemeEleChar) {
       holder.createInfoAnnotation(element, null)
-              .setTextAttributes(SchemeSyntaxHighlighter.CHAR);
+              .setTextAttributes(syntaxHighlighter.CHAR);
     } else if (element instanceof SchemeBadCharacter/* || element instanceof SchemeBadElement*/) {
       holder.createInfoAnnotation(element, null)
-              .setTextAttributes(SchemeSyntaxHighlighter.BAD_CHARACTER);
+              .setTextAttributes(syntaxHighlighter.BAD_CHARACTER);
     } else if (element instanceof SchemeEleString) {
       holder.createInfoAnnotation(element, null)
-              .setTextAttributes(SchemeSyntaxHighlighter.STRING);
+              .setTextAttributes(syntaxHighlighter.STRING);
 
       String eStr = "abtnvfr\"\\\t\r\n";
       String str = element.getText();
@@ -62,7 +68,7 @@ public class SchemeAnnotator implements Annotator
               holder.createInfoAnnotation(new TextRange(
                               startOffset + slashPos,
                               startOffset + idx + 1), null)
-                      .setTextAttributes(SchemeSyntaxHighlighter.STRING_ESCAPE);
+                      .setTextAttributes(syntaxHighlighter.STRING_ESCAPE);
               idx = idx + 1;
             }
           }
@@ -70,7 +76,7 @@ public class SchemeAnnotator implements Annotator
           holder.createInfoAnnotation(new TextRange(
                           startOffset + slashPos,
                           startOffset + slashPos + 2), null)
-                  .setTextAttributes(SchemeSyntaxHighlighter.STRING_ESCAPE);
+                  .setTextAttributes(syntaxHighlighter.STRING_ESCAPE);
           idx = slashPos + 2;
         } else {
           idx = slashPos + 2;

--- a/src/main/highlighter/SchemeSyntaxHighlighter.java
+++ b/src/main/highlighter/SchemeSyntaxHighlighter.java
@@ -59,28 +59,27 @@ public class SchemeSyntaxHighlighter extends SyntaxHighlighterBase implements Sc
   public static final String DOT_ID = "Scheme Dot";
   public static final String ABBREVIATION_ID = "Scheme Abbreviation";
 
-  public static TextAttributesKey COMMENT = createTextAttributesKey(COMMENT_ID, defaultFor(SyntaxHighlighterColors.LINE_COMMENT));
-  public static TextAttributesKey IDENTIFIER = createTextAttributesKey(IDENTIFIER_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
-  public static TextAttributesKey NUMBER = createTextAttributesKey(NUMBER_ID, defaultFor(SyntaxHighlighterColors.NUMBER));
-  public static TextAttributesKey STRING = createTextAttributesKey(STRING_ID, defaultFor(SyntaxHighlighterColors.STRING));
-  public static TextAttributesKey STRING_ESCAPE = createTextAttributesKey(STRING_ESCAPE_ID, defaultFor(SyntaxHighlighterColors.VALID_STRING_ESCAPE));
-  public static TextAttributesKey BRACE = createTextAttributesKey(BRACES_ID, defaultFor(SyntaxHighlighterColors.BRACES));
-  public static TextAttributesKey PAREN = createTextAttributesKey(PAREN_ID, defaultFor(SyntaxHighlighterColors.PARENTHS));
-  public static TextAttributesKey LITERAL = createTextAttributesKey(LITERAL_ID, defaultFor(HighlighterColors.TEXT));
-  public static TextAttributesKey CHAR = createTextAttributesKey(CHAR_ID, defaultFor(SyntaxHighlighterColors.STRING));
-  public static TextAttributesKey BAD_CHARACTER = createTextAttributesKey(BAD_CHARACTER_ID, defaultFor(HighlighterColors.BAD_CHARACTER));
-  public static TextAttributesKey KEYWORD = createTextAttributesKey(KEYWORD_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
-  public static TextAttributesKey PROCEDURE = createTextAttributesKey(PROCEDURE_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
-  public static TextAttributesKey SPECIAL = createTextAttributesKey(SPECIAL_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
-  public static TextAttributesKey QUOTED_TEXT = createTextAttributesKey(QUOTED_TEXT_ID, brighter(HighlighterColors.TEXT));
-  public static TextAttributesKey QUOTED_STRING = createTextAttributesKey(QUOTED_STRING_ID, brighter(SyntaxHighlighterColors.STRING));
-  public static TextAttributesKey QUOTED_NUMBER = createTextAttributesKey(QUOTED_NUMBER_ID, brighter(SyntaxHighlighterColors.NUMBER));
-  public static TextAttributesKey DOT = createTextAttributesKey(DOT_ID, brighter(SyntaxHighlighterColors.DOT));
-  public static TextAttributesKey ABBREVIATION = createTextAttributesKey(ABBREVIATION_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
+  public TextAttributesKey COMMENT = createTextAttributesKey(COMMENT_ID, defaultFor(SyntaxHighlighterColors.LINE_COMMENT));
+  public TextAttributesKey IDENTIFIER = createTextAttributesKey(IDENTIFIER_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
+  public TextAttributesKey NUMBER = createTextAttributesKey(NUMBER_ID, defaultFor(SyntaxHighlighterColors.NUMBER));
+  public TextAttributesKey STRING = createTextAttributesKey(STRING_ID, defaultFor(SyntaxHighlighterColors.STRING));
+  public TextAttributesKey STRING_ESCAPE = createTextAttributesKey(STRING_ESCAPE_ID, defaultFor(SyntaxHighlighterColors.VALID_STRING_ESCAPE));
+  public TextAttributesKey BRACE = createTextAttributesKey(BRACES_ID, defaultFor(SyntaxHighlighterColors.BRACES));
+  public TextAttributesKey PAREN = createTextAttributesKey(PAREN_ID, defaultFor(SyntaxHighlighterColors.PARENTHS));
+  public TextAttributesKey LITERAL = createTextAttributesKey(LITERAL_ID, defaultFor(HighlighterColors.TEXT));
+  public TextAttributesKey CHAR = createTextAttributesKey(CHAR_ID, defaultFor(SyntaxHighlighterColors.STRING));
+  public TextAttributesKey BAD_CHARACTER = createTextAttributesKey(BAD_CHARACTER_ID, defaultFor(HighlighterColors.BAD_CHARACTER));
+  public TextAttributesKey KEYWORD = createTextAttributesKey(KEYWORD_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
+  public TextAttributesKey PROCEDURE = createTextAttributesKey(PROCEDURE_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
+  public TextAttributesKey SPECIAL = createTextAttributesKey(SPECIAL_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
+  public TextAttributesKey QUOTED_TEXT = createTextAttributesKey(QUOTED_TEXT_ID, brighter(HighlighterColors.TEXT));
+  public TextAttributesKey QUOTED_STRING = createTextAttributesKey(QUOTED_STRING_ID, brighter(SyntaxHighlighterColors.STRING));
+  public TextAttributesKey QUOTED_NUMBER = createTextAttributesKey(QUOTED_NUMBER_ID, brighter(SyntaxHighlighterColors.NUMBER));
+  public TextAttributesKey DOT = createTextAttributesKey(DOT_ID, brighter(SyntaxHighlighterColors.DOT));
+  public TextAttributesKey ABBREVIATION = createTextAttributesKey(ABBREVIATION_ID, defaultFor(SyntaxHighlighterColors.KEYWORD));
 
   public static TextAttributesKey[] EMPTY_KEYS = new TextAttributesKey[0];
 
-  static
   {
     newFillMap(ATTRIBUTES, pack(COMMENT),
             SchemeTokens.LINE_COMMENT, SchemeTokens.BLOCK_COMMENT, SchemeTokens.DATUM_COMMENT);
@@ -99,11 +98,11 @@ public class SchemeSyntaxHighlighter extends SyntaxHighlighterBase implements Sc
             SchemeTokens.SYNTAX, SchemeTokens.QUASISYNTAX, SchemeTokens.UNSYNTAX, SchemeTokens.UNSYNTAX_SPLICING);
   }
 
-  protected static void newFillMap(@NotNull Map<IElementType, TextAttributesKey[]> map, TextAttributesKey[] value, @NotNull TokenSet keys) {
+  protected void newFillMap(@NotNull Map<IElementType, TextAttributesKey[]> map, TextAttributesKey[] value, @NotNull TokenSet keys) {
     newFillMap(map, value, keys.getTypes());
   }
 
-  protected static void newFillMap(@NotNull Map<IElementType, TextAttributesKey[]> map, TextAttributesKey[] value, @NotNull IElementType... types) {
+  protected void newFillMap(@NotNull Map<IElementType, TextAttributesKey[]> map, TextAttributesKey[] value, @NotNull IElementType... types) {
     IElementType[] var3 = types;
     int var4 = types.length;
 
@@ -113,12 +112,12 @@ public class SchemeSyntaxHighlighter extends SyntaxHighlighterBase implements Sc
     }
   }
 
-  private static TextAttributes defaultFor(TextAttributesKey key)
+  private TextAttributes defaultFor(TextAttributesKey key)
   {
     return key.getDefaultAttributes();
   }
 
-  private static TextAttributes brighter(TextAttributesKey key)
+  private TextAttributes brighter(TextAttributesKey key)
   {
     TextAttributes attributes = key.getDefaultAttributes().clone();
     Color foregroundColor = attributes.getForegroundColor();

--- a/src/main/psi/impl/SchemeSymbol.java
+++ b/src/main/psi/impl/SchemeSymbol.java
@@ -2,6 +2,7 @@ package main.psi.impl;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.fileTypes.ExtensionFileNameMatcher;
 import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Iconable;
@@ -397,7 +398,12 @@ public class SchemeSymbol extends SchemePsiElementBase  implements PsiReference
 
   private PsiFile getFilesByName(@NotNull Project project, @NotNull String name, @NotNull GlobalSearchScope scope)
   {
-    String[] exts = FileTypeManager.getInstance().getAssociatedExtensions(SchemeFileType.SCHEME_FILE_TYPE);
+    String[] exts =  FileTypeManager.getInstance().getAssociations(SchemeFileType.SCHEME_FILE_TYPE)
+        .stream()
+        .filter(matcher -> matcher instanceof ExtensionFileNameMatcher)
+        .map(matcher -> ((ExtensionFileNameMatcher) matcher).getExtension())
+        .toArray(String[]::new);
+
     for (String ext : exts) {
       PsiFile[] files = FilenameIndex.getFilesByName(project, name + "." + ext, scope);
       if (files.length > 0) {

--- a/src/main/settings/colorScheme/SchemeColorsAndFontsPage.java
+++ b/src/main/settings/colorScheme/SchemeColorsAndFontsPage.java
@@ -40,27 +40,31 @@ public class SchemeColorsAndFontsPage implements ColorSettingsPage
     return ATTRS;
   }
 
-  private static final
-  AttributesDescriptor[]
-    ATTRS =
-    new AttributesDescriptor[]{desc(SchemeSyntaxHighlighter.IDENTIFIER_ID, SchemeSyntaxHighlighter.IDENTIFIER),
-                               desc(SchemeSyntaxHighlighter.COMMENT_ID, SchemeSyntaxHighlighter.COMMENT),
+  private final SchemeSyntaxHighlighter syntaxHighlighter;
+  private final AttributesDescriptor[] ATTRS;
+
+  SchemeColorsAndFontsPage(SchemeSyntaxHighlighter syntaxHighlighter) {
+    this.syntaxHighlighter = syntaxHighlighter;
+    this.ATTRS =
+        new AttributesDescriptor[]{desc(SchemeSyntaxHighlighter.IDENTIFIER_ID, syntaxHighlighter.IDENTIFIER),
+            desc(SchemeSyntaxHighlighter.COMMENT_ID, syntaxHighlighter.COMMENT),
 //                               desc(SchemeSyntaxHighlighter.BLOCK_COMMENT_ID, SchemeSyntaxHighlighter.BLOCK_COMMENT),
 //                               desc(SchemeSyntaxHighlighter.DATUM_COMMENT_ID, SchemeSyntaxHighlighter.DATUM_COMMENT),
-                               desc(SchemeSyntaxHighlighter.NUMBER_ID, SchemeSyntaxHighlighter.NUMBER),
-                               desc(SchemeSyntaxHighlighter.STRING_ID, SchemeSyntaxHighlighter.STRING),
-                               desc(SchemeSyntaxHighlighter.BRACES_ID, SchemeSyntaxHighlighter.BRACE),
-                               desc(SchemeSyntaxHighlighter.PAREN_ID, SchemeSyntaxHighlighter.PAREN),
-                               desc(SchemeSyntaxHighlighter.BAD_CHARACTER_ID, SchemeSyntaxHighlighter.BAD_CHARACTER),
-                               desc(SchemeSyntaxHighlighter.CHAR_ID, SchemeSyntaxHighlighter.CHAR),
-                               desc(SchemeSyntaxHighlighter.LITERAL_ID, SchemeSyntaxHighlighter.LITERAL),
-                               desc(SchemeSyntaxHighlighter.KEYWORD_ID, SchemeSyntaxHighlighter.KEYWORD),
-                               desc(SchemeSyntaxHighlighter.PROCEDURE_ID, SchemeSyntaxHighlighter.PROCEDURE),
-                               desc(SchemeSyntaxHighlighter.SPECIAL_ID, SchemeSyntaxHighlighter.SPECIAL),
-                               desc(SchemeSyntaxHighlighter.QUOTED_TEXT_ID, SchemeSyntaxHighlighter.QUOTED_TEXT),
-                               desc(SchemeSyntaxHighlighter.QUOTED_STRING_ID, SchemeSyntaxHighlighter.QUOTED_STRING),
-                               desc(SchemeSyntaxHighlighter.QUOTED_NUMBER_ID, SchemeSyntaxHighlighter.QUOTED_NUMBER),
-    };
+            desc(SchemeSyntaxHighlighter.NUMBER_ID, syntaxHighlighter.NUMBER),
+            desc(SchemeSyntaxHighlighter.STRING_ID, syntaxHighlighter.STRING),
+            desc(SchemeSyntaxHighlighter.BRACES_ID, syntaxHighlighter.BRACE),
+            desc(SchemeSyntaxHighlighter.PAREN_ID, syntaxHighlighter.PAREN),
+            desc(SchemeSyntaxHighlighter.BAD_CHARACTER_ID, syntaxHighlighter.BAD_CHARACTER),
+            desc(SchemeSyntaxHighlighter.CHAR_ID, syntaxHighlighter.CHAR),
+            desc(SchemeSyntaxHighlighter.LITERAL_ID, syntaxHighlighter.LITERAL),
+            desc(SchemeSyntaxHighlighter.KEYWORD_ID, syntaxHighlighter.KEYWORD),
+            desc(SchemeSyntaxHighlighter.PROCEDURE_ID, syntaxHighlighter.PROCEDURE),
+            desc(SchemeSyntaxHighlighter.SPECIAL_ID, syntaxHighlighter.SPECIAL),
+            desc(SchemeSyntaxHighlighter.QUOTED_TEXT_ID, syntaxHighlighter.QUOTED_TEXT),
+            desc(SchemeSyntaxHighlighter.QUOTED_STRING_ID, syntaxHighlighter.QUOTED_STRING),
+            desc(SchemeSyntaxHighlighter.QUOTED_NUMBER_ID, syntaxHighlighter.QUOTED_NUMBER),
+        };
+  }
 
   private static AttributesDescriptor desc(String displayName, TextAttributesKey key)
   {
@@ -118,7 +122,7 @@ public class SchemeColorsAndFontsPage implements ColorSettingsPage
   public Map<String, TextAttributesKey> getAdditionalHighlightingTagToDescriptorMap()
   {
     Map<String, TextAttributesKey> map = new HashMap<String, TextAttributesKey>();
-    map.put("def", SchemeSyntaxHighlighter.IDENTIFIER);
+    map.put("def", syntaxHighlighter.IDENTIFIER);
     return map;
   }
 }


### PR DESCRIPTION
Problems addressed:
- a compilation error caused by `FileTypeManager.getAssociatedExtensions()` no longer existing
- a runtime exception caused by `TextAttributesKey#getDefaultAttributes()` no longer being allowed to be called from static context